### PR TITLE
feat: add values-scenario{1,2,3,4}.yaml for learning roadmap

### DIFF
--- a/chart/values-baseline.yaml
+++ b/chart/values-baseline.yaml
@@ -1,3 +1,4 @@
+# DEPRECATED: Use values-scenario1.yaml instead (P5 learning roadmap)
 # Baseline configuration (no resilience patterns)
 # Used for baseline measurements in S1 and S4 scenarios
 

--- a/chart/values-resilient.yaml
+++ b/chart/values-resilient.yaml
@@ -1,3 +1,4 @@
+# DEPRECATED: Use values-scenario3.yaml or values-scenario4.yaml instead
 # Resilient configuration (P0 patterns enabled)
 # Used for resilient measurements in S1 and S4 scenarios
 

--- a/chart/values-s1.yaml
+++ b/chart/values-s1.yaml
@@ -1,3 +1,4 @@
+# DEPRECATED: Use values-scenario1.yaml + values-scenario3.yaml instead
 # Scenario S1: Overload scenario
 # Tests behavior when B is overloaded with high QPS
 

--- a/chart/values-s4.yaml
+++ b/chart/values-s4.yaml
@@ -1,3 +1,4 @@
+# DEPRECATED: Use values-scenario4.yaml instead
 # Scenario S4: Connection reset scenario
 # Tests behavior when gRPC connection to B is abruptly reset
 

--- a/chart/values-scenario1.yaml
+++ b/chart/values-scenario1.yaml
@@ -1,0 +1,11 @@
+# Scenario 1 — Baseline: no resilience, no retry
+# Failure mode: FAIL_RATE=0.3 (30% RESOURCE_EXHAUSTED)
+# Lesson: raw failure propagates end-to-end
+appA:
+  env:
+    - {name: RESILIENCE_ENABLED, value: "false"}
+    - {name: RETRY_ENABLED,      value: "false"}
+appB:
+  env:
+    - {name: B_DELAY_MS, value: "5"}
+    - {name: FAIL_RATE,  value: "0.3"}

--- a/chart/values-scenario2.yaml
+++ b/chart/values-scenario2.yaml
@@ -1,0 +1,12 @@
+# Scenario 2 — +Retry+Idempotency
+# Failure mode: same FAIL_RATE=0.3
+# Lesson: gRPC retry absorbs ~90% of transient errors; also shows retry
+#         amplifies load under slow B (anti-pattern lesson follows in S3)
+appA:
+  env:
+    - {name: RESILIENCE_ENABLED, value: "false"}
+    - {name: RETRY_ENABLED,      value: "true"}
+appB:
+  env:
+    - {name: B_DELAY_MS, value: "5"}
+    - {name: FAIL_RATE,  value: "0.3"}

--- a/chart/values-scenario3.yaml
+++ b/chart/values-scenario3.yaml
@@ -1,0 +1,15 @@
+# Scenario 3 — +Deadline+Bulkhead+CircuitBreaker
+# Failure mode: B_DELAY_MS=200 (slow B triggers overload cascade)
+# Lesson: deadline + bulkhead + CB sever the overload cascade; retry without
+#         CB would amplify load — this scenario adds the guardrails
+appA:
+  env:
+    - {name: RESILIENCE_ENABLED, value: "true"}
+    - {name: RETRY_ENABLED,      value: "true"}
+    - {name: DEADLINE_MS,        value: "800"}
+    - {name: MAX_INFLIGHT,       value: "10"}
+    - {name: CHANNEL_POOL_SIZE,  value: "1"}
+appB:
+  env:
+    - {name: B_DELAY_MS, value: "200"}
+    - {name: FAIL_RATE,  value: "0.3"}

--- a/chart/values-scenario4.yaml
+++ b/chart/values-scenario4.yaml
@@ -1,0 +1,15 @@
+# Scenario 4 — +Keepalive+ChannelPool (+TCP reset fault injection)
+# Failure mode: iptables TCP reset injected at t=15s
+# Lesson: keepalive detects dead connections; channel pool distributes
+#         reconnection load; connection failure self-heals
+appA:
+  env:
+    - {name: RESILIENCE_ENABLED, value: "true"}
+    - {name: RETRY_ENABLED,      value: "true"}
+    - {name: DEADLINE_MS,        value: "800"}
+    - {name: MAX_INFLIGHT,       value: "10"}
+    - {name: CHANNEL_POOL_SIZE,  value: "4"}
+appB:
+  env:
+    - {name: B_DELAY_MS, value: "5"}
+    - {name: FAIL_RATE,  value: "0.3"}


### PR DESCRIPTION
## Summary
- 4 new Helm values files for P5 cumulative learning roadmap:
  - `values-scenario1.yaml`: RESILIENCE=false, RETRY=false, FAIL_RATE=0.3
  - `values-scenario2.yaml`: RESILIENCE=false, RETRY=true, FAIL_RATE=0.3
  - `values-scenario3.yaml`: RESILIENCE=true, RETRY=true, B_DELAY_MS=200, CHANNEL_POOL_SIZE=1
  - `values-scenario4.yaml`: RESILIENCE=true, RETRY=true, CHANNEL_POOL_SIZE=4, FAIL_RATE=0.3
- Old values files (`baseline`, `resilient`, `s1`, `s4`) kept with `# DEPRECATED:` header

## DoD Proof
- `ls chart/values-scenario*.yaml | wc -l` → 4 ✓
- `helm lint chart -f values-common -f values-scenario1` → 0 failed ✓
- `helm lint chart -f values-common -f values-scenario4` → 0 failed ✓

Closes #23