### PR TITLE
refactor: rename BClient → AppA to clarify dual role

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -116,7 +116,7 @@ Fixes #21
 ```
 
 ```bash
-refactor: rename BClient → AppA to clarify dual role
+refactor: rename AppA classes to clarify dual HTTP/gRPC role
 
 Fixes #32
 ```

--- a/apps/app-a/src/main/java/com/demo/appa/AppA.java
+++ b/apps/app-a/src/main/java/com/demo/appa/AppA.java
@@ -18,8 +18,8 @@ import javax.annotation.PreDestroy;
 
 @Component
 @ConditionalOnExpression("'${resilience.enabled:false}' == 'false' && '${retry.enabled:false}' == 'false'")
-public class BClient implements BClientPort {
-    private static final Logger logger = LoggerFactory.getLogger(BClient.class);
+public class AppA implements AppAPort {
+    private static final Logger logger = LoggerFactory.getLogger(AppA.class);
 
     @Value("${b.service.url}")
     private String bServiceUrl;

--- a/apps/app-a/src/main/java/com/demo/appa/AppAPort.java
+++ b/apps/app-a/src/main/java/com/demo/appa/AppAPort.java
@@ -1,5 +1,5 @@
 package com.demo.appa;
 
-public interface BClientPort {
+public interface AppAPort {
     WorkResult callWork(String requestId);
 }

--- a/apps/app-a/src/main/java/com/demo/appa/ResilientAppA.java
+++ b/apps/app-a/src/main/java/com/demo/appa/ResilientAppA.java
@@ -28,8 +28,8 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 @Component
 @ConditionalOnProperty(name = "resilience.enabled", havingValue = "true")
-public class ResilientBClient implements BClientPort {
-    private static final Logger logger = LoggerFactory.getLogger(ResilientBClient.class);
+public class ResilientAppA implements AppAPort {
+    private static final Logger logger = LoggerFactory.getLogger(ResilientAppA.class);
 
     @Value("${b.service.url}")
     private String bServiceUrl;

--- a/apps/app-a/src/main/java/com/demo/appa/RetryAppA.java
+++ b/apps/app-a/src/main/java/com/demo/appa/RetryAppA.java
@@ -18,7 +18,7 @@ import java.util.Map;
 
 @Component
 @ConditionalOnExpression("'${retry.enabled:false}' == 'true' && '${resilience.enabled:false}' == 'false'")
-public class RetryBClient implements BClientPort {
+public class RetryAppA implements AppAPort {
 
     @Value("${b.service.url}") private String bServiceUrl;
     @Autowired private MetricsService metricsService;

--- a/apps/app-a/src/main/java/com/demo/appa/WorkController.java
+++ b/apps/app-a/src/main/java/com/demo/appa/WorkController.java
@@ -15,14 +15,14 @@ public class WorkController {
     private static final Logger logger = LoggerFactory.getLogger(WorkController.class);
 
     @Autowired
-    private BClientPort bClient;
+    private AppAPort appA;
 
     @GetMapping("/work")
     public WorkResponse work() {
         String requestId = UUID.randomUUID().toString();
         logger.info("Handling /api/work request: {}", requestId);
 
-        WorkResult result = bClient.callWork(requestId);
+        WorkResult result = appA.callWork(requestId);
 
         return new WorkResponse(
                 result.isOk(),

--- a/docs/plan2.md
+++ b/docs/plan2.md
@@ -58,13 +58,13 @@ not free; it must be paired with a circuit breaker.**
 
 | Pattern | Added in | File | Mechanism |
 |---|---|---|---|
-| gRPC retry | Scenario 2 | RetryBClient.java, ResilientBClient.java | gRPC service config: maxAttempts=3, RESOURCE_EXHAUSTED |
+| gRPC retry | Scenario 2 | RetryAppA.java, ResilientAppA.java | gRPC service config: maxAttempts=3, RESOURCE_EXHAUSTED |
 | Idempotency dedup | Scenario 2 | app-b/main.go | seenRequests sync.Map keyed on req.Id, 30s TTL |
-| Deadline | Scenario 3 | ResilientBClient.java | withDeadlineAfter(800ms) |
-| Bulkhead | Scenario 3 | ResilientBClient.java | Semaphore.tryAcquire(MAX_INFLIGHT) |
-| Circuit Breaker | Scenario 3 | ResilientBClient.java | Resilience4j COUNT_BASED(10), 50% threshold |
-| gRPC Keepalive | Scenario 4 | ResilientBClient.java | HTTP/2 PING every 30s, 10s timeout |
-| Channel Pool | Scenario 4 | ResilientBClient.java | N ManagedChannels, round-robin AtomicInteger |
+| Deadline | Scenario 3 | ResilientAppA.java | withDeadlineAfter(800ms) |
+| Bulkhead | Scenario 3 | ResilientAppA.java | Semaphore.tryAcquire(MAX_INFLIGHT) |
+| Circuit Breaker | Scenario 3 | ResilientAppA.java | Resilience4j COUNT_BASED(10), 50% threshold |
+| gRPC Keepalive | Scenario 4 | ResilientAppA.java | HTTP/2 PING every 30s, 10s timeout |
+| Channel Pool | Scenario 4 | ResilientAppA.java | N ManagedChannels, round-robin AtomicInteger |
 
 ---
 
@@ -72,9 +72,9 @@ not free; it must be paired with a circuit breaker.**
 
 | Client | RESILIENCE_ENABLED | RETRY_ENABLED | Scenario |
 |---|---|---|---|
-| BClient | false | false | 1 — baseline |
-| RetryBClient | false | true | 2 — retry only |
-| ResilientBClient | true | any | 3, 4 — full stack |
+| AppA | false | false | 1 — baseline |
+| RetryAppA | false | true | 2 — retry only |
+| ResilientAppA | true | any | 3, 4 — full stack |
 
 Activation is via Spring `@ConditionalOnExpression`. Only one client bean is
 active per deployment.
@@ -123,7 +123,7 @@ active per deployment.
 
 ```
 T13 (app-b: FAIL_RATE + dedup)
-  └─ T14 (app-a: RATE_LIMITED + RetryBClient + retry in Resilient)
+  └─ T14 (app-a: RATE_LIMITED + RetryAppA + retry in Resilient)
        └─ T15 (chart: values-scenario{1,2,3,4}.yaml)
             └─ T16 (run_scenario.sh rewrite)
                  └─ T17 (verify_scenario{2,3,4}.sh)


### PR DESCRIPTION
## Summary
App-a is both an HTTP server (receives from Fortio) and a gRPC client (calls app-b). The old name `BClient` implied "B is a client" rather than describing app-a's behavior. The new name `AppA` is neutral and shorter.

**Renames (4 files, `git mv` — history preserved):**
- `BClientPort.java` → `AppAPort.java`
- `BClient.java` → `AppA.java`
- `RetryBClient.java` → `RetryAppA.java`
- `ResilientBClient.java` → `ResilientAppA.java`

**Additional changes:**
- `WorkController.java`: `bClient` field → `appA`, `BClientPort` type → `AppAPort`
- Logger class refs updated: `BClient.class` → `AppA.class`, `ResilientBClient.class` → `ResilientAppA.class`
- `README.md`, `docs/plan2.md`, `CONTRIBUTING.md`: all BClient references updated

## DoD Proof
- `docker build app-a:dev` → exit 0, no compilation errors ✓
- `ls appa/*.java | sort` → AppA, AppAPort, ResilientAppA, RetryAppA (no BClient* files) ✓
- `grep -r BClient README.md docs/plan2.md docs/runbook.md CONTRIBUTING.md | wc -l` → 0 ✓

Closes #32