### PR TITLE
refactor: rename AppAFailFast to AppAResilient

### DIFF
--- a/apps/app-a/src/main/java/com/demo/appa/AppAResilient.java
+++ b/apps/app-a/src/main/java/com/demo/appa/AppAResilient.java
@@ -28,8 +28,8 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 @Component
 @ConditionalOnProperty(name = "resilience.enabled", havingValue = "true")
-public class AppAFailFast implements AppAPort {
-    private static final Logger logger = LoggerFactory.getLogger(AppAFailFast.class);
+public class AppAResilient implements AppAPort {
+    private static final Logger logger = LoggerFactory.getLogger(AppAResilient.class);
 
     @Value("${b.service.url}")
     private String bServiceUrl;

--- a/docs/plan2.md
+++ b/docs/plan2.md
@@ -58,13 +58,13 @@ not free; it must be paired with a circuit breaker.**
 
 | Pattern | Added in | File | Mechanism |
 |---|---|---|---|
-| gRPC retry | Scenario 2: Retry | AppARetry.java, AppAFailFast.java | gRPC service config: maxAttempts=3, RESOURCE_EXHAUSTED |
+| gRPC retry | Scenario 2: Retry | AppARetry.java, AppAResilient.java | gRPC service config: maxAttempts=3, RESOURCE_EXHAUSTED |
 | Idempotency dedup | Scenario 2: Retry | app-b/main.go | seenRequests sync.Map keyed on req.Id, 30s TTL |
-| Deadline | Scenario 3: Failfast | AppAFailFast.java | withDeadlineAfter(800ms) |
-| Bulkhead | Scenario 3: Failfast | AppAFailFast.java | Semaphore.tryAcquire(MAX_INFLIGHT) |
-| Circuit Breaker | Scenario 3: Failfast | AppAFailFast.java | Resilience4j COUNT_BASED(10), 50% threshold |
-| gRPC Keepalive | Scenario 4: Selfheal | AppAFailFast.java | HTTP/2 PING every 30s, 10s timeout |
-| Channel Pool | Scenario 4: Selfheal | AppAFailFast.java | N ManagedChannels, round-robin AtomicInteger |
+| Deadline | Scenario 3: Failfast | AppAResilient.java | withDeadlineAfter(800ms) |
+| Bulkhead | Scenario 3: Failfast | AppAResilient.java | Semaphore.tryAcquire(MAX_INFLIGHT) |
+| Circuit Breaker | Scenario 3: Failfast | AppAResilient.java | Resilience4j COUNT_BASED(10), 50% threshold |
+| gRPC Keepalive | Scenario 4: Selfheal | AppAResilient.java | HTTP/2 PING every 30s, 10s timeout |
+| Channel Pool | Scenario 4: Selfheal | AppAResilient.java | N ManagedChannels, round-robin AtomicInteger |
 
 ---
 
@@ -74,7 +74,7 @@ not free; it must be paired with a circuit breaker.**
 |---|---|---|---|
 | AppABaseline | false | false | 1 — baseline |
 | AppARetry | false | true | 2 — retry only |
-| AppAFailFast | true | any | 3, 4 — full stack |
+| AppAResilient | true | any | 3, 4 — full stack |
 
 Activation is via Spring `@ConditionalOnExpression`. Only one client bean is
 active per deployment.
@@ -123,7 +123,7 @@ active per deployment.
 
 ```
 T13 (app-b: FAIL_RATE + dedup)
-  └─ T14 (app-a: BACKEND_ERROR + AppARetry + retry in AppAFailFast)
+  └─ T14 (app-a: BACKEND_ERROR + AppARetry + retry in AppAResilient)
        └─ T15 (chart: values-{baseline,retry,failfast,selfheal}.yaml)
             └─ T16 (run_scenario.sh rewrite)
                  └─ T17 (verify_scenario{2,3,4}.sh)


### PR DESCRIPTION
## Problem

`AppAFailFast` was confusing because it's used by **both** Scenario 3: Failfast and Scenario 4: Selfheal, but the name suggests it's specific to S3.

## Solution

Renamed `AppAFailFast` → `AppAResilient` to clarify that this is the **full resilience implementation** containing all 7 patterns:

- Retry
- Deadline
- Bulkhead (inflight limit)
- Circuit Breaker
- Keepalive
- Channel Pool

## Key Insight

Scenario 3 and 4 use the **same code** but **different configuration**:

| Scenario | CHANNEL_POOL_SIZE | B_DELAY_MS | Fault | Focus |
|---|---|---|---|---|
| 3: Failfast | 1 (no pool) | 200 (slow) | none | Deadline + Bulkhead + CB |
| 4: Selfheal | 4 (pool active) | 5 (normal) | TCP reset | Keepalive + Pool |

When `CHANNEL_POOL_SIZE=1`, the pool code exists but creates only 1 channel (effectively bypassing the pool benefit).

## Changes

- Renamed: `AppAFailFast.java` → `AppAResilient.java`
- Updated class name and logger reference
- Updated all documentation (README, plan2)
- Build verified ✓

Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)