### PR TITLE
fix: Workstream A.1 - enable histogram buckets and clarify taxonomy

### DIFF
--- a/apps/app-a/src/main/java/com/demo/appa/AppAResilient.java
+++ b/apps/app-a/src/main/java/com/demo/appa/AppAResilient.java
@@ -134,8 +134,13 @@ public class AppAResilient implements AppAPort {
         if (!semaphore.tryAcquire()) {
             circuitBreaker.releasePermission();
             logger.warn("Bulkhead full (QUEUE_FULL) for request {}", requestId);
+
+            // NEW: Use standard "BULKHEAD_REJECTED" reason for new metrics
             metricsService.recordCall("Work", 0, null, "BULKHEAD_REJECTED");
+
+            // LEGACY: Keep QUEUE_FULL for backward compatibility
             metricsService.recordDownstreamCall(0, ErrorCode.QUEUE_FULL);
+
             return new WorkResult(false, ErrorCode.QUEUE_FULL.name(), 0, ErrorCode.QUEUE_FULL);
         }
 

--- a/apps/app-a/src/main/java/com/demo/appa/MetricsService.java
+++ b/apps/app-a/src/main/java/com/demo/appa/MetricsService.java
@@ -107,10 +107,21 @@ public class MetricsService {
             .increment();
 
         // Histogram: grpc_client_latency_ms
+        // Enable histogram buckets for PromQL histogram_quantile() queries
         Timer.builder("grpc_client_latency_ms")
             .description("gRPC client request latency")
             .tag("service", "demo-service-b")
             .tag("method", method)
+            .serviceLevelObjectives(
+                Duration.ofMillis(10),
+                Duration.ofMillis(50),
+                Duration.ofMillis(100),
+                Duration.ofMillis(200),
+                Duration.ofMillis(500),
+                Duration.ofMillis(1000),
+                Duration.ofMillis(2000),
+                Duration.ofMillis(5000)
+            )
             .register(registry)
             .record(latencyMs, TimeUnit.MILLISECONDS);
     }

--- a/docs/workstream_observability_requirements.md
+++ b/docs/workstream_observability_requirements.md
@@ -35,6 +35,8 @@ Records latency for both success and failure.
 | `BULKHEAD_REJECTED` | No | Semaphore full |
 | `UNKNOWN` | No | Fallback |
 
+**Note:** Legacy code uses `ErrorCode.QUEUE_FULL` for the same protection event. In the new metrics taxonomy, this maps to `reason=BULKHEAD_REJECTED` to use standard resilience terminology.
+
 ---
 
 ## Implementation


### PR DESCRIPTION
## Summary

Fixes 2 critical issues identified in Workstream A review before moving to Workstream B.

---

## Fix 1: Enable Histogram Buckets ✅

**Problem:**
- PromQL queries use `histogram_quantile(...grpc_client_latency_ms_bucket...)`
- But `Timer.builder().record()` didn't emit `_bucket` metrics
- Result: P95/P99 panels would return no data

**Solution:**
Added `.serviceLevelObjectives()` to Timer builder with 8 SLO buckets:
- 10ms, 50ms, 100ms, 200ms, 500ms, 1000ms, 2000ms, 5000ms

**Files changed:**
- `MetricsService.java`: Added SLO buckets to grpc_client_latency_ms timer

**Verification:**
After deployment, `/actuator/prometheus` will now show:
```
grpc_client_latency_ms_bucket{le="0.01",...} 0.0
grpc_client_latency_ms_bucket{le="0.05",...} 123.0
grpc_client_latency_ms_bucket{le="0.1",...} 456.0
...
grpc_client_latency_ms_bucket{le="+Inf",...} 11800.0
```

---

## Fix 2: Clarify Taxonomy Mapping (QUEUE_FULL → BULKHEAD_REJECTED) ✅

**Problem:**
- Legacy code uses `ErrorCode.QUEUE_FULL`
- New metrics use `reason=BULKHEAD_REJECTED`
- Risk of confusion in dashboards and Workstream B retry policy

**Solution:**
1. Added explicit comments in `AppAResilient.java` showing dual metrics:
   - New metric: `BULKHEAD_REJECTED` (standard resilience terminology)
   - Legacy metric: `QUEUE_FULL` (backward compatibility)

2. Documented mapping in `workstream_observability_requirements.md`:
   - "Legacy `ErrorCode.QUEUE_FULL` maps to `reason=BULKHEAD_REJECTED`"

**Files changed:**
- `AppAResilient.java`: Added comments explaining dual recording
- `workstream_observability_requirements.md`: Added mapping note

---

## Other Observations (Acknowledged, Not Fixed)

**A) result label uses SUCCESS/FAILURE instead of OK/ERROR**
- ✅ Consistent across code and docs, no change needed

**B) RESOURCE_EXHAUSTED → BACKEND_ERROR + retryable=true**
- ✅ Acceptable for Scenario 2 teaching, can refine in Workstream B

**C) Legacy metric `a_downstream_errors_total` name is misleading**
- ✅ Legacy behavior preserved, okay for now

---

## Testing

- [x] `mvn clean compile` - BUILD SUCCESS
- [x] `mvn test` - 11/11 tests pass, 0 failures
- [ ] Deploy and verify `grpc_client_latency_ms_bucket` appears
- [ ] Verify PromQL query 03_p95_latency.promql returns data

---

## Definition of Done

- [x] Histogram SLO buckets configured
- [x] Code comments added for dual metrics recording
- [x] Documentation updated with taxonomy mapping
- [x] Build succeeds
- [x] All tests pass
- [ ] Histogram buckets verified in Prometheus (needs deployment)
- [ ] P95 PromQL query returns data (needs deployment)

---

Closes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)