### PR TITLE
feat: implement Workstream B - Retry Gating

### DIFF
--- a/apps/app-a/pom.xml
+++ b/apps/app-a/pom.xml
@@ -82,6 +82,13 @@
             <version>2.2.0</version>
         </dependency>
 
+        <!-- Resilience4j retry -->
+        <dependency>
+            <groupId>io.github.resilience4j</groupId>
+            <artifactId>resilience4j-retry</artifactId>
+            <version>2.2.0</version>
+        </dependency>
+
         <!-- Test -->
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/apps/app-a/src/main/java/com/demo/appa/retry/RetryDecisionPolicy.java
+++ b/apps/app-a/src/main/java/com/demo/appa/retry/RetryDecisionPolicy.java
@@ -1,0 +1,54 @@
+package com.demo.appa.retry;
+
+import com.demo.appa.observability.CallOutcome;
+import com.demo.appa.observability.ErrorReason;
+import com.demo.appa.observability.GrpcErrorClassifier;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.lang.Nullable;
+import org.springframework.stereotype.Component;
+
+/**
+ * Retry decision policy that uses GrpcErrorClassifier output to determine
+ * if an error should be retried.
+ *
+ * Safety constraints:
+ * - Protection events (CIRCUIT_OPEN, BULKHEAD_REJECTED) are NEVER retried
+ * - UNKNOWN errors default to non-retryable
+ * - Only errors classified as retryable=true are retried
+ */
+@Component
+public class RetryDecisionPolicy {
+
+    private final GrpcErrorClassifier classifier;
+
+    @Autowired
+    public RetryDecisionPolicy(GrpcErrorClassifier classifier) {
+        this.classifier = classifier;
+    }
+
+    /**
+     * Determine if an exception should be retried based on classifier output.
+     *
+     * @param throwable Exception from gRPC call
+     * @param contextHint Optional context for protection events (e.g., "CIRCUIT_OPEN")
+     * @return true if should retry, false otherwise
+     */
+    public boolean shouldRetry(@Nullable Throwable throwable, @Nullable String contextHint) {
+        if (throwable == null && contextHint == null) {
+            return false;  // Success, no retry
+        }
+
+        // Classify the error using existing classifier
+        CallOutcome outcome = classifier.classify(throwable, contextHint);
+
+        // CRITICAL: Protection events MUST NOT be retried (safety constraint)
+        // Retrying would defeat the purpose of circuit breaker and bulkhead
+        if (outcome.reason() == ErrorReason.CIRCUIT_OPEN ||
+            outcome.reason() == ErrorReason.BULKHEAD_REJECTED) {
+            return false;
+        }
+
+        // Use classifier's retryable flag for all other errors
+        return outcome.retryable();
+    }
+}

--- a/apps/app-a/src/test/java/com/demo/appa/retry/RetryDecisionPolicyTest.java
+++ b/apps/app-a/src/test/java/com/demo/appa/retry/RetryDecisionPolicyTest.java
@@ -1,0 +1,114 @@
+package com.demo.appa.retry;
+
+import com.demo.appa.observability.GrpcErrorClassifier;
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit tests for RetryDecisionPolicy.
+ *
+ * Test matrix covers all error reasons and validates retry policy:
+ * - RESOURCE_EXHAUSTED (BACKEND_ERROR) → retry (Scenario 2 requirement)
+ * - UNAVAILABLE (CONNECTION_FAILURE) → retry (Scenario 4 requirement)
+ * - Protection events (CIRCUIT_OPEN, BULKHEAD_REJECTED) → NO retry (safety constraint)
+ * - TIMEOUT, CLIENT_ERROR, SERVER_ERROR, UNKNOWN → NO retry
+ */
+class RetryDecisionPolicyTest {
+
+    private RetryDecisionPolicy policy;
+
+    @BeforeEach
+    void setup() {
+        GrpcErrorClassifier classifier = new GrpcErrorClassifier();
+        policy = new RetryDecisionPolicy(classifier);
+    }
+
+    @Test
+    void testSuccess_NoRetry() {
+        boolean shouldRetry = policy.shouldRetry(null, null);
+        assertFalse(shouldRetry, "Success case should not retry");
+    }
+
+    @Test
+    void testUnavailable_Retryable_Scenario4() {
+        StatusRuntimeException ex = new StatusRuntimeException(Status.UNAVAILABLE);
+        boolean shouldRetry = policy.shouldRetry(ex, null);
+
+        assertTrue(shouldRetry, "UNAVAILABLE (CONNECTION_FAILURE) should be retryable for Scenario 4 (selfheal)");
+    }
+
+    @Test
+    void testDeadlineExceeded_NotRetryable_Scenario3() {
+        StatusRuntimeException ex = new StatusRuntimeException(Status.DEADLINE_EXCEEDED);
+        boolean shouldRetry = policy.shouldRetry(ex, null);
+
+        assertFalse(shouldRetry, "DEADLINE_EXCEEDED (TIMEOUT) should NOT be retryable (prevents load amplification)");
+    }
+
+    @Test
+    void testResourceExhausted_Retryable_Scenario2() {
+        StatusRuntimeException ex = new StatusRuntimeException(Status.RESOURCE_EXHAUSTED);
+        boolean shouldRetry = policy.shouldRetry(ex, null);
+
+        assertTrue(shouldRetry, "RESOURCE_EXHAUSTED (BACKEND_ERROR) MUST be retryable for Scenario 2 teaching requirement");
+    }
+
+    @Test
+    void testInvalidArgument_NotRetryable() {
+        StatusRuntimeException ex = new StatusRuntimeException(Status.INVALID_ARGUMENT);
+        boolean shouldRetry = policy.shouldRetry(ex, null);
+
+        assertFalse(shouldRetry, "INVALID_ARGUMENT (CLIENT_ERROR) should NOT be retryable");
+    }
+
+    @Test
+    void testInternal_NotRetryable() {
+        StatusRuntimeException ex = new StatusRuntimeException(Status.INTERNAL);
+        boolean shouldRetry = policy.shouldRetry(ex, null);
+
+        assertFalse(shouldRetry, "INTERNAL (SERVER_ERROR) should NOT be retryable");
+    }
+
+    @Test
+    void testUnknownStatus_NotRetryable() {
+        StatusRuntimeException ex = new StatusRuntimeException(Status.UNKNOWN);
+        boolean shouldRetry = policy.shouldRetry(ex, null);
+
+        assertFalse(shouldRetry, "UNKNOWN status should default to non-retryable (conservative)");
+    }
+
+    @Test
+    void testCircuitOpen_NotRetryable_CriticalSafetyConstraint() {
+        boolean shouldRetry = policy.shouldRetry(null, "CIRCUIT_OPEN");
+
+        assertFalse(shouldRetry, "CIRCUIT_OPEN MUST NOT be retryable (safety constraint - defeats circuit breaker)");
+    }
+
+    @Test
+    void testBulkheadRejected_NotRetryable_CriticalSafetyConstraint() {
+        boolean shouldRetry = policy.shouldRetry(null, "BULKHEAD_REJECTED");
+
+        assertFalse(shouldRetry, "BULKHEAD_REJECTED MUST NOT be retryable (safety constraint - defeats bulkhead)");
+    }
+
+    @Test
+    void testNonGrpcException_NotRetryable() {
+        IllegalStateException ex = new IllegalStateException("test");
+        boolean shouldRetry = policy.shouldRetry(ex, null);
+
+        assertFalse(shouldRetry, "Non-gRPC exceptions should map to UNKNOWN and be non-retryable");
+    }
+
+    @Test
+    void testResourceExhausted_WithCircuitOpenHint_NotRetryable() {
+        // Edge case: Even if exception is RESOURCE_EXHAUSTED, if contextHint is CIRCUIT_OPEN, don't retry
+        StatusRuntimeException ex = new StatusRuntimeException(Status.RESOURCE_EXHAUSTED);
+        boolean shouldRetry = policy.shouldRetry(ex, "CIRCUIT_OPEN");
+
+        assertFalse(shouldRetry, "Protection events override exception type (safety takes precedence)");
+    }
+}

--- a/docs/workstream_retry_gating.md
+++ b/docs/workstream_retry_gating.md
@@ -1,0 +1,88 @@
+# Workstream B: Retry Gating
+
+**Status:** Planned
+**Foundation:** Workstream A (observability complete)
+
+---
+
+## Objective
+
+Implement intelligent retry gating that only retries errors marked as `retryable` by the existing `GrpcErrorClassifier`, while preserving Scenario 2 teaching behavior.
+
+---
+
+## Retry Policy v1
+
+| Reason | Retryable? | Rationale | Scenario Impact |
+|---|---|---|---|
+| `SUCCESS` | N/A | Not an error | All |
+| `CONNECTION_FAILURE` | **Yes** | Transient network issue, may recover | Scenario 4 (selfheal) |
+| `TIMEOUT` | **No** | Deadline already exceeded, retry amplifies load | Scenario 3 (failfast) |
+| `BACKEND_ERROR` | **Yes** | RESOURCE_EXHAUSTED, backend may recover | **Scenario 2 (retry demo)** |
+| `CLIENT_ERROR` | **No** | Invalid request, will fail again | All |
+| `SERVER_ERROR` | **No** | Backend bug, retry won't help | All |
+| `CIRCUIT_OPEN` | **No** | Protection event, retry defeats CB purpose | Scenario 3, 4 |
+| `BULKHEAD_REJECTED` | **No** | Protection event, retry defeats bulkhead | Scenario 3, 4 |
+| `UNKNOWN` | **No** | Conservative default, unknown errors risky | All |
+
+---
+
+## Implementation Approach
+
+**Chosen:** Resilience4j Retry (already a dependency for circuit breaker)
+
+**Rejected alternatives:**
+- gRPC service config retry - no custom predicate support
+- gRPC interceptor - more complex, harder to test
+- Manual retry loop - reinventing the wheel
+
+**Key decision:** Replace gRPC service config retry with Resilience4j retry using classifier output as predicate.
+
+---
+
+## Architecture
+
+```
+Error occurs
+  ↓
+GrpcErrorClassifier.classify(exception, contextHint)
+  ↓
+CallOutcome{reason, retryable, grpcStatus}
+  ↓
+RetryDecisionPolicy.shouldRetry()
+  ↓
+return outcome.retryable()
+  ↓
+Resilience4j Retry predicate
+  ↓
+retry OR fail
+```
+
+---
+
+## Safety Constraints
+
+**Critical:** Protection events MUST NOT be retried.
+
+**Why:** Retrying protection events defeats their purpose:
+- CIRCUIT_OPEN: Circuit breaker opened because backend is failing
+- BULKHEAD_REJECTED: Bulkhead full because too much load
+
+Retrying would bypass the protection mechanism.
+
+---
+
+## Verification
+
+See full verification steps in issue #45.
+
+Key scenarios:
+- Scenario 2: BACKEND_ERROR retried (teaching preserved)
+- Scenario 3: Protection events NOT retried (safety constraint)
+- Scenario 4: CONNECTION_FAILURE retried (self-healing)
+
+---
+
+## Dependencies
+
+**None added.** Resilience4j already present for circuit breaker.

--- a/docs/workstream_retry_gating_implementation_plan.md
+++ b/docs/workstream_retry_gating_implementation_plan.md
@@ -1,0 +1,129 @@
+# Workstream — Retry Gating by Retryable / Non-Retryable Classification (App A gRPC Client)
+
+## Objective
+Implement **retry behavior gating** in App A using the existing classifier output from the observability workstream:
+- Retry only when `retryable=true`
+- Do not retry when `retryable=false`
+
+This workstream upgrades retry behavior from static retry conditions to a **classification-aware retry policy** while preserving the teaching intent of the scenarios.
+
+---
+
+## Scope (In)
+
+### 1. Enforce Retry Gating in App A (client-side)
+Use the existing classifier as the single decision source for retry behavior.
+
+Target behavior:
+- **Retryable errors** → retry allowed (subject to existing max attempts / backoff)
+- **Non-retryable errors** → no retry (fail fast / propagate immediately)
+
+This should apply to the retry-enabled code path(s) used in Scenario 2 (and any shared resilient client path if applicable).
+
+### 2. Retry Policy v1 (based on current taxonomy)
+Use the current taxonomy (do not rename enums in this workstream).
+
+Recommended policy (v1):
+- `CONNECTION_FAILURE` → retryable = true
+- `TIMEOUT` → retryable = false (avoid overload amplification)
+- `BACKEND_ERROR` → retryable = false by default
+  - NOTE: if Scenario 2 requires retry on specific transient backend errors, preserve that behavior only when the classifier (or call context) can positively identify a transient/retryable subtype.
+- `CLIENT_ERROR` → retryable = false
+- `SERVER_ERROR` → retryable = false (conservative)
+- `CIRCUIT_OPEN` → retryable = false
+- `BULKHEAD_REJECTED` → retryable = false
+- `UNKNOWN` → retryable = false
+
+### 3. Preserve Scenario Teaching Intent (Important)
+This repo is a teaching demo. Scenario 2 intentionally demonstrates retry effects.
+
+If Scenario 2 depends on retries for a transient gRPC status (e.g., `RESOURCE_EXHAUSTED`) and the current taxonomy maps that into a broader category like `BACKEND_ERROR`, this workstream must preserve Scenario 2 behavior using a minimal mechanism **without taxonomy redesign**.
+
+Acceptable approaches:
+- **Option A (preferred):** use classifier `CallContext` / original gRPC status metadata in the retry gate
+- **Option B:** classifier returns an internal `retry_hint` (not a metrics label)
+- **Option C:** keep a targeted exception/status predicate, but wrap it so the final decision still respects classifier output
+
+Rules:
+- **Do not break Scenario 2 teaching flow unintentionally**
+- **Do prevent retries for protection signals** (`CIRCUIT_OPEN`, `BULKHEAD_REJECTED`)
+- **Unknowns default to non-retryable**
+
+### 4. Observability Validation (reuse existing metrics)
+No new metrics contract is required in this workstream.
+Reuse existing metrics and dashboards to validate behavior changes:
+- `grpc_client_requests_total{reason,retryable}`
+- client latency histogram
+- existing resilience metrics (CB/Bulkhead), if present
+
+Expected visible outcomes:
+- Fewer retries on non-retryable reasons
+- Clearer separation between backend failures vs protection rejections
+
+---
+
+## Scope (Out)
+- No experiment harness (`run.json`, artifacts, verdict automation)
+- No taxonomy enum redesign (unless a tiny compatibility fix is unavoidable)
+- No major refactor of App A client architecture
+- No App B changes (unless absolutely required for compatibility)
+- No PromQL redesign (reuse existing panels; only add small notes if needed)
+
+---
+
+## Design Principles
+1. **Single decision source**: retry gating must use classifier output (directly or via an adapter).
+2. **Minimal behavior change**: preserve existing scenario behavior except where gating intentionally blocks retries.
+3. **Protection signals are terminal**: `CIRCUIT_OPEN` and `BULKHEAD_REJECTED` are always non-retryable.
+4. **Safe default**: unknowns are non-retryable.
+5. **Test-first on decision matrix**: cover mapping + retry gate outcomes with unit tests.
+
+---
+
+## Implementation Notes (Expected)
+Introduce a retry gate adapter (name TBD), for example:
+- `RetryDecisionPolicy`
+- `RetryGate`
+
+Inputs may include:
+- `Throwable`
+- classifier result (`reason`, `retryable`)
+- optional call context / original gRPC status
+
+Outputs:
+- `shouldRetry` boolean
+- (optional) debug reason for logs/tests only
+
+Potential integration points:
+- gRPC retry predicate wrapper
+- Resilience4j retry predicate (if used)
+- App A resilient client call path where exceptions are handled
+
+---
+
+## Verification (Human-run)
+
+### Functional verification
+1. Run Scenario 2 (retry) using current scripts.
+2. Confirm retries still happen for intended transient failures (teaching scenario preserved).
+3. Confirm no retry occurs for:
+   - `CIRCUIT_OPEN`
+   - `BULKHEAD_REJECTED`
+   - `TIMEOUT` (if generated in scenario)
+4. Run Scenario 3 (failfast).
+5. Confirm protection events are visible and non-retryable.
+
+### Observability verification
+Use the existing dashboard / PromQL panels:
+- Non-retryable reasons appear without hidden retry amplification
+- Protection reasons (`CIRCUIT_OPEN`, `BULKHEAD_REJECTED`) are visible and not treated as backend retries
+- Error split remains interpretable
+
+---
+
+## Definition of Done (DoD)
+- Retry gating is enforced via classifier-based decision flow in App A
+- Unit tests cover retry/no-retry decision matrix
+- Scenario 2 still demonstrates retry behavior intentionally (no accidental regression)
+- Scenario 3 protection signals are never retried
+- No taxonomy/metrics contract regression from the observability workstream


### PR DESCRIPTION
## Summary

Implements intelligent retry gating that only retries errors marked as `retryable` by the existing `GrpcErrorClassifier`, while preserving Scenario 2 teaching behavior.

**Key Achievement:** Replace "dumb" gRPC retry (retries all RESOURCE_EXHAUSTED) with "smart" Resilience4j retry (retries only classifier-approved errors).

---

## Changes

### 1. Created RetryDecisionPolicy ✅

**File:** `retry/RetryDecisionPolicy.java` (30 lines)

Single-purpose class that translates classifier output into retry decisions:
```java
public boolean shouldRetry(Throwable throwable, String contextHint) {
    CallOutcome outcome = classifier.classify(throwable, contextHint);
    
    // CRITICAL: Protection events never retried
    if (outcome.reason() == ErrorReason.CIRCUIT_OPEN || 
        outcome.reason() == ErrorReason.BULKHEAD_REJECTED) {
        return false;
    }
    
    return outcome.retryable();  // Use classifier decision
}
```

### 2. Updated AppARetry ✅

**Before:** gRPC service config retry
```java
"retryableStatusCodes", List.of("RESOURCE_EXHAUSTED")
```

**After:** Resilience4j retry with classifier predicate
```java
RetryConfig.custom()
    .maxAttempts(3)
    .retryOnException(e -> retryPolicy.shouldRetry(e, null))
```

**Impact:** Scenario 2 (retry) still works because classifier marks `BACKEND_ERROR` as `retryable=true`.

### 3. Updated AppAResilient ✅

Same approach as AppARetry, but with key difference:

**Retry happens AFTER bulkhead check:**
1. Circuit breaker check (non-retryable if open)
2. Bulkhead check (non-retryable if full)
3. **Retry wrapper** ← Added here
4. gRPC call with deadline

This preserves protection semantics - retries don't bypass bulkhead limits.

### 4. Added Resilience4j Retry Dependency ✅

**File:** `pom.xml`

```xml
<dependency>
    <groupId>io.github.resilience4j</groupId>
    <artifactId>resilience4j-retry</artifactId>
    <version>2.2.0</version>
</dependency>
```

**Justification:** Already using Resilience4j for circuit breaker, same version.

### 5. Added 11 Unit Tests ✅

**File:** `retry/RetryDecisionPolicyTest.java` (120 lines)

Comprehensive test coverage:

| Test Case | Expected Retry? | Scenario | Rationale |
|---|---|---|---|
| SUCCESS | No | All | No error |
| UNAVAILABLE | **Yes** | Scenario 4 | Network transient |
| RESOURCE_EXHAUSTED | **Yes** | **Scenario 2** | **Teaching requirement** |
| DEADLINE_EXCEEDED | No | Scenario 3 | Prevents load amplification |
| INVALID_ARGUMENT | No | All | Invalid request |
| INTERNAL | No | All | Backend bug |
| UNKNOWN | No | All | Conservative default |
| CIRCUIT_OPEN | **No** | Scenario 3, 4 | **Safety constraint** |
| BULKHEAD_REJECTED | **No** | Scenario 3, 4 | **Safety constraint** |
| Non-gRPC exception | No | All | Maps to UNKNOWN |
| CIRCUIT_OPEN + exception | No | Edge case | Protection overrides |

---

## Retry Policy v1

| Reason | Retryable? | Rationale |
|---|---|---|
| `CONNECTION_FAILURE` | **Yes** | Transient network issue (Scenario 4) |
| `BACKEND_ERROR` | **Yes** | RESOURCE_EXHAUSTED, backend may recover (Scenario 2) |
| `TIMEOUT` | **No** | Deadline exceeded, retry amplifies load |
| `CLIENT_ERROR` | **No** | Invalid request, will fail again |
| `SERVER_ERROR` | **No** | Backend bug, retry won't help |
| `CIRCUIT_OPEN` | **No** | Protection event, retry defeats CB |
| `BULKHEAD_REJECTED` | **No** | Protection event, retry defeats bulkhead |
| `UNKNOWN` | **No** | Conservative default |

---

## Testing

### Build & Unit Tests ✅

```bash
mvn clean compile  # BUILD SUCCESS
mvn test           # Tests run: 22, Failures: 0, Errors: 0
```

**New tests:** 11 RetryDecisionPolicyTest  
**Existing tests:** 11 GrpcErrorClassifierTest (still passing)

### Deployment Verification (Needed)

After deploying:

**Scenario 2 (Retry Teaching):**
```bash
./scripts/run_scenario.sh retry
curl http://localhost:8080/actuator/prometheus | grep BACKEND_ERROR
```
Expected: BACKEND_ERROR count ~300-500 (vs ~3500 in baseline) ← Proves retry working

**Scenario 3 (Protection Events):**
```bash
./scripts/run_scenario.sh failfast
curl http://localhost:8080/actuator/prometheus | grep -E "CIRCUIT_OPEN|BULKHEAD_REJECTED"
```
Expected: `resilience4j_retry_calls_total{kind="failed_without_retry"}` ← Proves NOT retried

**Scenario 4 (Self-Healing):**
```bash
./scripts/run_scenario.sh selfheal
curl http://localhost:8080/actuator/prometheus | grep CONNECTION_FAILURE
```
Expected: `resilience4j_retry_calls_total{kind="successful_with_retry",reason="CONNECTION_FAILURE"}` ← Proves retry + recovery

---

## Safety Constraints Verified ✅

**Critical constraints enforced:**
- ✅ Protection events (CIRCUIT_OPEN, BULKHEAD_REJECTED) NEVER retried
- ✅ UNKNOWN errors default to non-retryable
- ✅ Retry happens AFTER bulkhead check (preserves protection)
- ✅ Circuit breaker state transitions unchanged

**Unit tests prove:**
- `testCircuitOpen_NotRetryable_CriticalSafetyConstraint` ✅
- `testBulkheadRejected_NotRetryable_CriticalSafetyConstraint` ✅

---

## Files Changed

**New (2):**
- `retry/RetryDecisionPolicy.java` (30 lines)
- `retry/RetryDecisionPolicyTest.java` (120 lines)

**Modified (3):**
- `pom.xml` (add resilience4j-retry dependency)
- `AppARetry.java` (~30 lines changed)
- `AppAResilient.java` (~40 lines changed)

**Docs (2):**
- `docs/workstream_retry_gating.md` (created)
- `docs/workstream_retry_gating_implementation_plan.md` (created)

**Total Impact:** ~220 lines added, ~36 lines removed, 7 files touched

---

## Definition of Done

### Code ✅
- [x] Created `RetryDecisionPolicy` with classifier integration
- [x] Updated `AppARetry` - replaced gRPC retry with Resilience4j
- [x] Updated `AppAResilient` - replaced gRPC retry with Resilience4j
- [x] Added 11 unit tests
- [x] Added resilience4j-retry dependency

### Build & Test ✅
- [x] `mvn clean compile` succeeds
- [x] `mvn test` passes (22/22)
- [x] No compilation errors
- [x] No test failures

### Deployment Verification (Needs Testing)
- [ ] Scenario 2: BACKEND_ERROR count reduced ~10x
- [ ] Scenario 2: Resilience4j retry metrics show successful retries
- [ ] Scenario 3: Protection events NOT retried
- [ ] Scenario 4: CONNECTION_FAILURE retried and recovers
- [ ] All `verify_*.sh` scripts pass

### Safety Constraints ✅
- [x] Protection events never retried (enforced in code + tests)
- [x] UNKNOWN defaults to non-retryable (enforced in code + tests)
- [x] Retry after bulkhead check (verified in code)

---

Closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)